### PR TITLE
cronjob api

### DIFF
--- a/k8s/popeye/cronjob.yml
+++ b/k8s/popeye/cronjob.yml
@@ -1,6 +1,6 @@
 # Sample Popeye CronJob. Runs Popeye as a cron every hours
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: popeye


### PR DESCRIPTION
The batch/v1beta1 API version of CronJob is no longer served as of v1.25.